### PR TITLE
optimize concurrent multi-block requests

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -258,8 +258,11 @@ func (b srao) adapterOpt(a *Adapter) error {
 	return nil
 }
 
-//SplitRanges is an option to prevent making MultiRead try to merge
-//consecutive ranges into a single block request
+// SplitRanges is an option to prevent making MultiRead try to merge
+// consecutive ranges into a single block request
+//
+// Deprecated: osio now automatically splits a request into individual
+// blocks when needed
 func SplitRanges(splitRanges bool) interface {
 	AdapterOption
 } {

--- a/adapter.go
+++ b/adapter.go
@@ -411,7 +411,6 @@ func (a *Adapter) getRange(key string, rng blockRange) ([][]byte, error) {
 		}(int64(i))
 	}
 	wg.Wait()
-	//no need to unlock, as none were aquired in this case
 	return blocks, err
 }
 

--- a/adapter.go
+++ b/adapter.go
@@ -448,7 +448,6 @@ func (a *Adapter) applyBlock(mu *sync.Mutex, block int64, data []byte, written [
 }
 
 func (a *Adapter) ReadAtMulti(key string, bufs [][]byte, offsets []int64) ([]int, error) {
-	//fmt.Printf("readmulti %v\n", offsets)
 	blids := make(map[int64]bool)
 	errmu := sync.Mutex{}
 	for ibuf := range bufs {
@@ -562,7 +561,6 @@ func (a *Adapter) blockKey(key string, id int64) string {
 }
 
 func (a *Adapter) getBlock(key string, id int64) ([]byte, error) {
-	//fmt.Printf("get block %d\n", id)
 	blockData, ok := a.cache.Get(key, uint(id))
 	if ok {
 		return blockData, nil

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -389,18 +389,22 @@ func TestRangeErrors(t *testing.T) {
 	}
 	bc, _ := NewAdapter(er, BlockSize("5"))
 
+	wg := sync.WaitGroup{}
+	wg.Add(2)
 	go func() {
+		defer wg.Done()
 		buf := make([]byte, 15)
 		_, err := bc.ReadAt("", buf, 0)
 		assert.NoError(t, err)
 	}()
 	time.Sleep(5 * time.Millisecond)
 	go func() {
+		defer wg.Done()
 		buf := make([]byte, 7)
 		_, err := bc.ReadAt("", buf, 11)
 		assert.ErrorIs(t, err, io.EOF)
 	}()
-	time.Sleep(110 * time.Millisecond)
+	wg.Wait()
 
 	//check reader error returned
 	er = EReader{
@@ -411,16 +415,19 @@ func TestRangeErrors(t *testing.T) {
 	}
 	bc, _ = NewAdapter(er, BlockSize("5"))
 
+	wg.Add(2)
 	go func() {
+		defer wg.Done()
 		buf := make([]byte, 15)
 		_, err := bc.ReadAt("", buf, 0)
 		assert.NoError(t, err)
 	}()
 	time.Sleep(5 * time.Millisecond)
 	go func() {
+		defer wg.Done()
 		buf := make([]byte, 15)
 		_, err := bc.ReadAt("", buf, 6)
 		assert.Equal(t, "foo", err.Error())
 	}()
-	time.Sleep(110 * time.Millisecond)
+	wg.Wait()
 }

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -355,3 +355,72 @@ func TestReader(t *testing.T) {
 	assert.Equal(t, []byte{255, 255, 255, 255}, bufs[1])
 
 }
+
+type EReader struct {
+	errbuf []byte
+	delay  time.Duration
+	erroff int64
+	err    error
+}
+
+func (r EReader) ReadAt(key string, buf []byte, off int64) (int, int64, error) {
+	ll := int64(len(r.errbuf))
+	time.Sleep(r.delay)
+	if r.err != nil && off >= r.erroff {
+		return 0, 0, r.err
+	}
+	if int(off) > len(r.errbuf) {
+		return 0, ll, io.EOF
+	}
+	n := copy(buf, r.errbuf[off:])
+	var err error
+	if n < len(buf) {
+		err = io.EOF
+	}
+	return n, ll, err
+}
+
+//provide test coverage of reader errors in multi-block requests
+func TestRangeErrors(t *testing.T) {
+	//check small last block
+	er := EReader{
+		delay:  100 * time.Millisecond,
+		errbuf: []byte("abcd-efgh-ijkl-m"),
+	}
+	bc, _ := NewAdapter(er, BlockSize("5"))
+
+	go func() {
+		buf := make([]byte, 15)
+		_, err := bc.ReadAt("", buf, 0)
+		assert.NoError(t, err)
+	}()
+	time.Sleep(5 * time.Millisecond)
+	go func() {
+		buf := make([]byte, 7)
+		_, err := bc.ReadAt("", buf, 11)
+		assert.ErrorIs(t, err, io.EOF)
+	}()
+	time.Sleep(110 * time.Millisecond)
+
+	//check reader error returned
+	er = EReader{
+		delay:  100 * time.Millisecond,
+		errbuf: []byte("abcd-efgh-ijkl-m"),
+		erroff: 15,
+		err:    fmt.Errorf("foo"),
+	}
+	bc, _ = NewAdapter(er, BlockSize("5"))
+
+	go func() {
+		buf := make([]byte, 15)
+		_, err := bc.ReadAt("", buf, 0)
+		assert.NoError(t, err)
+	}()
+	time.Sleep(5 * time.Millisecond)
+	go func() {
+		buf := make([]byte, 15)
+		_, err := bc.ReadAt("", buf, 6)
+		assert.Equal(t, "foo", err.Error())
+	}()
+	time.Sleep(110 * time.Millisecond)
+}

--- a/gcs.go
+++ b/gcs.go
@@ -94,7 +94,7 @@ func (gcs *GCSHandler) ReadAt(key string, p []byte, off int64) (int, int64, erro
 		gbucket = gbucket.UserProject(gcs.billingProjectID)
 	}
 	r, err := gbucket.Object(object).NewRangeReader(gcs.ctx, off, int64(len(p)))
-	//fmt.Printf("read %s [%d-%d]\n", key, off/(1024*1024), (off+int64(len(p)))/(1024*1024))
+	//fmt.Printf("read %s [%d-%d]\n", key, off, off+int64(len(p)))
 	if err != nil {
 		var gerr *googleapi.Error
 		if off > 0 && errors.As(err, &gerr) && gerr.Code == 416 {

--- a/gcs.go
+++ b/gcs.go
@@ -94,7 +94,7 @@ func (gcs *GCSHandler) ReadAt(key string, p []byte, off int64) (int, int64, erro
 		gbucket = gbucket.UserProject(gcs.billingProjectID)
 	}
 	r, err := gbucket.Object(object).NewRangeReader(gcs.ctx, off, int64(len(p)))
-	//fmt.Printf("read %s [%d-%d]\n", key, off, off+int64(len(p)))
+	fmt.Printf("read %s [%d-%d]\n", key, off/(1024*1024), (off+int64(len(p)))/(1024*1024))
 	if err != nil {
 		var gerr *googleapi.Error
 		if off > 0 && errors.As(err, &gerr) && gerr.Code == 416 {

--- a/gcs.go
+++ b/gcs.go
@@ -94,7 +94,7 @@ func (gcs *GCSHandler) ReadAt(key string, p []byte, off int64) (int, int64, erro
 		gbucket = gbucket.UserProject(gcs.billingProjectID)
 	}
 	r, err := gbucket.Object(object).NewRangeReader(gcs.ctx, off, int64(len(p)))
-	fmt.Printf("read %s [%d-%d]\n", key, off/(1024*1024), (off+int64(len(p)))/(1024*1024))
+	//fmt.Printf("read %s [%d-%d]\n", key, off/(1024*1024), (off+int64(len(p)))/(1024*1024))
 	if err != nil {
 		var gerr *googleapi.Error
 		if off > 0 && errors.As(err, &gerr) && gerr.Code == 416 {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,5 @@ require (
 	cloud.google.com/go/storage v1.15.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/stretchr/testify v1.7.0
-	github.com/vburenin/nsync v0.0.0-20160822015540-9a75d1c80410
 	google.golang.org/api v0.46.0
 )

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/vburenin/nsync v0.0.0-20160822015540-9a75d1c80410 h1:NcdnJbCrXag4rJ1eoXgYKVgsm/1eHlZPzBNRybiPCE4=
-github.com/vburenin/nsync v0.0.0-20160822015540-9a75d1c80410/go.mod h1:J5O5BmZ9QYZGTELKzppJxisaWthI0I/HkbhAYn3qsZM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/namedoncemutex.go
+++ b/namedoncemutex.go
@@ -1,0 +1,117 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Volodymyr Burenin
+// Copyright (c) 2021 Airbus Defence and Space
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package osio
+
+import "sync"
+
+// onceMutex is a mutex that can be locked only once.
+// Lock operation returns true if mutex has been successfully locked.
+// Any other concurrent attempts will block until mutex is unlocked.
+// However, any other attempts to grab a lock will return false.
+type onceMutex struct {
+	mu   sync.Mutex
+	used bool
+}
+
+// Lock tries to acquire lock.
+func (om *onceMutex) Lock() bool {
+	om.mu.Lock()
+	if om.used {
+		om.mu.Unlock()
+		return false
+	}
+	return true
+}
+
+// Unlock tries to release a lock.
+func (om *onceMutex) Unlock() {
+	om.used = true
+	om.mu.Unlock()
+}
+
+// NamedOnceMutex is a map of dynamically created mutexes by provided id.
+// First attempt to lock by id will create a new mutex and acquire a lock.
+// All other concurrent attempts will block waiting mutex to be unlocked for the same id.
+// Once mutex unlocked, all other lock attempts will return false for the same instance of mutex.
+// Unlocked mutex is discarded. Next attempt to acquire a lock for the same id will succeed.
+// Such behaviour may be used to refresh a local cache of data identified by some key avoiding
+// concurrent request to receive a refreshed value for the same key.
+type namedOnceMutex struct {
+	lockMap map[interface{}]*onceMutex
+	mutex   sync.Mutex
+}
+
+// NewNamedOnceMutex returns an instance of NamedOnceMutex.
+func newNamedOnceMutex() *namedOnceMutex {
+	return &namedOnceMutex{
+		lockMap: make(map[interface{}]*onceMutex),
+	}
+}
+
+// Lock try to acquire a lock for provided id. If attempt is successful, true is returned
+// If lock is already acquired by something else it will block until mutex is unlocked returning false.
+func (nom *namedOnceMutex) Lock(useMutexKey interface{}) bool {
+	nom.mutex.Lock()
+	m, ok := nom.lockMap[useMutexKey]
+	if ok {
+		nom.mutex.Unlock()
+		return m.Lock()
+	}
+
+	m = &onceMutex{}
+	m.Lock()
+	nom.lockMap[useMutexKey] = m
+	nom.mutex.Unlock()
+	return true
+}
+
+// TryLock try to acquire a lock for provided id. If attempt is successful, true is returned
+// If lock is already acquired by something else it will return false.
+func (nom *namedOnceMutex) TryLock(useMutexKey interface{}) bool {
+	nom.mutex.Lock()
+	_, ok := nom.lockMap[useMutexKey]
+	if ok {
+		nom.mutex.Unlock()
+		return false
+	}
+
+	m := &onceMutex{}
+	m.Lock()
+	nom.lockMap[useMutexKey] = m
+	nom.mutex.Unlock()
+	return true
+}
+
+// Unlock unlocks the locked mutex. Used mutex will be discarded.
+func (nom *namedOnceMutex) Unlock(useMutexKey interface{}) {
+	nom.mutex.Lock()
+	m, ok := nom.lockMap[useMutexKey]
+	if ok {
+		delete(nom.lockMap, useMutexKey)
+		nom.mutex.Unlock()
+		m.Unlock()
+	} else {
+		nom.mutex.Unlock()
+	}
+}

--- a/namedoncemutex_test.go
+++ b/namedoncemutex_test.go
@@ -58,4 +58,6 @@ func TestNamedOnceMutex(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	n1.Unlock(key)
 	<-ww
+
+	n1.Unlock(key) //check second unlock
 }

--- a/namedoncemutex_test.go
+++ b/namedoncemutex_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Airbus Defence and Space
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package osio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamedOnceMutex(t *testing.T) {
+	key := "foo"
+	n1 := newNamedOnceMutex()
+	l1 := n1.Lock(key)
+	assert.True(t, l1)
+	l1 = n1.TryLock(key)
+	assert.False(t, l1)
+
+	ww := make(chan bool)
+	go func() {
+		l1 = n1.Lock(key)
+		assert.False(t, l1)
+		close(ww)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	n1.Unlock(key)
+	<-ww
+
+	l1 = n1.Lock(key)
+	assert.True(t, l1)
+	n1.Unlock(key)
+
+	l1 = n1.TryLock(key)
+	assert.True(t, l1)
+	l1 = n1.TryLock(key)
+	assert.False(t, l1)
+
+	ww = make(chan bool)
+	go func() {
+		l1 = n1.Lock(key)
+		assert.False(t, l1)
+		close(ww)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	n1.Unlock(key)
+	<-ww
+}


### PR DESCRIPTION
Fall back to SplitRanges() behavior on concurrent multi block reads. This kicks-in in the following case:

```
request 1 needs blocks: ABCD
request 2 needs blocks:  BCDEF
```

With SplitRanges(true), which after this PR will be deprecated, osio will make 6 requests for each individual block.
Each block may be read in the context of either request 1 or 2, depending on who managed to aquire the
lock on each individual block.

Before this patch, osio would emit a 4-block read (ABCD) for request 1, and a 5-block read (BCDEF) for request 2.
i.e. 3 blocks (BCD) will have been read twice instead of once.

After this patch, depending on lock ordering, osio will either emit:

- a 4-block read (ABCD) for request 1, and 2 1-block reads (E),(F) for request 2 (A future enhancement could be added so that request 2 emits a single (EF) read in this case. This is not addressed in this PR)
- a 5-block read (BCDEF) for request 2, and a 1-block read (A) for request 1


