### PR TITLE
KeyStreamerAt

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -387,19 +387,20 @@ func SizeCache(numEntries int) interface {
 	return scao{numEntries}
 }
 
-// NewAdapter creates a caching adapter around the provided KeyReaderAt
-//
-// NewAdapter will only return an error if you do not provide plausible options
-// (e.g. negative number of blocks or sizes, nil caches, etc...)
 const (
 	DefaultBlockSize       = 128 * 1024
 	DefaultNumCachedBlocks = 100
 )
 
+// NewAdapter creates a caching adapter around the provided KeyReaderAt.
+//
+// NewAdapter will only return an error if you do not provide plausible options
+// (e.g. negative number of blocks or sizes, nil caches, etc...)
 func NewAdapter(keyReader KeyReaderAt, opts ...AdapterOption) (*Adapter, error) {
 	return newAdapter(keyReader, nil, opts...)
 }
 
+// NewStreamingAdapter creates a caching adapter around the provided KeyStreamerAt.
 func NewStreamingAdapter(keyStreamer KeyStreamerAt, opts ...AdapterOption) (*Adapter, error) {
 	keyReader, ok := keyStreamer.(KeyReaderAt)
 	if !ok {

--- a/adapter.go
+++ b/adapter.go
@@ -60,7 +60,7 @@ type KeyStreamerAt interface {
 	// If the stream fails because the object does not exist, StreamAt must return syscall.ENOENT
 	// (or a wrapped error of syscall.ENOENT)
 	//
-	// The reader returns by StreamAt must follow the standard io.ReadCloser convention with respect
+	// The reader returned by StreamAt must follow the standard io.ReadCloser convention with respect
 	// to error handling.
 	//
 	// Clients of StreamAt can execute parallel StreamAt calls on the same input source.
@@ -111,7 +111,8 @@ type NamedOnceMutex interface {
 	Unlock(key interface{})
 }
 
-// Adapter caches fixed-sized chunks of a KeyStreamerAt, and exposes a proxy KeyStreamerAt
+// Adapter caches fixed-sized chunks of a KeyStreamerAt, and exposes
+// ReadAt(key string, buf []byte, offset int64) (int, error)
 // that feeds from its internal cache, only falling back to the provided KeyStreamerAt whenever
 // data could not be retrieved from its internal cache, while ensuring that concurrent requests
 // only result in a single call to the source reader.

--- a/adapter.go
+++ b/adapter.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -81,7 +82,7 @@ func (w readerAtToStreamerAtWrapper) StreamAt(key string, off int64, tot int64) 
 	if err == io.EOF {
 		err = nil
 	}
-	return io.NopCloser(bytes.NewReader(p[:n])), size, err
+	return ioutil.NopCloser(bytes.NewReader(p[:n])), size, err
 }
 
 // BlockCacher is the interface that wraps block caching functionality

--- a/gcs.go
+++ b/gcs.go
@@ -52,7 +52,7 @@ func GCSBillingProject(projectID string) GCSOption {
 
 // GCSHandle creates a KeyReaderAt suitable for constructing an Adapter
 // that accesses objects on Google Cloud Storage
-func GCSHandle(ctx context.Context, opts ...GCSOption) (KeyReaderAt, error) {
+func GCSHandle(ctx context.Context, opts ...GCSOption) (*GCSHandler, error) {
 	handler := &GCSHandler{
 		ctx: ctx,
 	}
@@ -66,7 +66,7 @@ func GCSHandle(ctx context.Context, opts ...GCSOption) (KeyReaderAt, error) {
 		}
 		handler.client = cl
 	}
-	return keyReaderAtWrapper{handler}, nil
+	return handler, nil
 }
 
 func (gcs *GCSHandler) StreamAt(key string, off int64, n int64) (io.ReadCloser, int64, error) {
@@ -90,4 +90,8 @@ func (gcs *GCSHandler) StreamAt(key string, off int64, n int64) (io.ReadCloser, 
 		return nil, 0, fmt.Errorf("new reader for gs://%s/%s: %w", bucket, object, err)
 	}
 	return r, r.Attrs.Size, err
+}
+
+func (gcs *GCSHandler) ReadAt(key string, p []byte, off int64) (int, int64, error) {
+	return keyReadFull(gcs, key, p, off)
 }

--- a/gcs.go
+++ b/gcs.go
@@ -93,5 +93,5 @@ func (gcs *GCSHandler) StreamAt(key string, off int64, n int64) (io.ReadCloser, 
 }
 
 func (gcs *GCSHandler) ReadAt(key string, p []byte, off int64) (int, int64, error) {
-	return keyReadFull(gcs, key, p, off)
+	panic("deprecated (kept for retrocompatibility)")
 }

--- a/http.go
+++ b/http.go
@@ -58,7 +58,7 @@ func HTTPHeader(key, value string) HTTPOption {
 
 // HTTPHandle creates a KeyReaderAt suitable for constructing an Adapter
 // that accesses objects using the http protocol
-func HTTPHandle(ctx context.Context, opts ...HTTPOption) (KeyReaderAt, error) {
+func HTTPHandle(ctx context.Context, opts ...HTTPOption) (*HTTPHandler, error) {
 	handler := &HTTPHandler{
 		ctx: ctx,
 	}
@@ -68,7 +68,7 @@ func HTTPHandle(ctx context.Context, opts ...HTTPOption) (KeyReaderAt, error) {
 	if handler.client == nil {
 		handler.client = &http.Client{}
 	}
-	return keyReaderAtWrapper{handler}, nil
+	return handler, nil
 }
 
 func handleResponse(r *http.Response) (io.ReadCloser, int64, error) {
@@ -116,4 +116,8 @@ func (h *HTTPHandler) StreamAt(key string, off int64, n int64) (io.ReadCloser, i
 		return handleResponse(r)
 	}
 	return r.Body, size, err
+}
+
+func (h *HTTPHandler) ReadAt(key string, p []byte, off int64) (int, int64, error) {
+	return keyReadFull(h, key, p, off)
 }

--- a/http.go
+++ b/http.go
@@ -119,5 +119,5 @@ func (h *HTTPHandler) StreamAt(key string, off int64, n int64) (io.ReadCloser, i
 }
 
 func (h *HTTPHandler) ReadAt(key string, p []byte, off int64) (int, int64, error) {
-	return keyReadFull(h, key, p, off)
+	panic("deprecated (kept for retrocompatibility)")
 }

--- a/s3.go
+++ b/s3.go
@@ -115,5 +115,5 @@ func (h *S3Handler) StreamAt(key string, off int64, n int64) (io.ReadCloser, int
 }
 
 func (h *S3Handler) ReadAt(key string, p []byte, off int64) (int, int64, error) {
-	return keyReadFull(h, key, p, off)
+	panic("deprecated (kept for retrocompatibility)")
 }


### PR DESCRIPTION
The PR concerns the following changes:
- introduction of the `KeyStreamerAt` interface to stream blocks instead of fetching them using `KeyReaderAt`. This has the benefits of reducing lock contention and allocation of large byte buffers.
- refacto of existing handlers so that they implement both `KeyStreamerAt` and the original API `KeyReaderAt` using a wrapper. 

