### PR TITLE
Fix rare missed sizecache lookup when first block is present

### DIFF
--- a/adapter_test.go
+++ b/adapter_test.go
@@ -466,3 +466,12 @@ func TestLogging(t *testing.T) {
 	_, _ = r.Read(buf)
 	assert.Contains(t, lbuf.String(), "GET thekey off=0 len=131072")
 }
+
+func TestSizeCacheEviction(t *testing.T) {
+	bc, _ := NewAdapter(rr, SizeCache(1))
+	_, err := bc.Size("thekey")
+	assert.NoError(t, err)
+	_, _ = bc.Size("enoent")
+	_, err = bc.Size("thekey")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
In some rare occasions, the size of a given key may have been evicted
from the lru sizecache, but the first block of the key might still be
present in the lru block cache. In that case the Size() call will fail
with the "BUG: size cache miss" error message.

This PR will force an actual read from the underlying keyReader so as
to repopulate the key's size in the lru sizecache
